### PR TITLE
RequestHelper properly returns null if response isnt JSON

### DIFF
--- a/client/Cryson/RequestHelper.j
+++ b/client/Cryson/RequestHelper.j
@@ -91,7 +91,7 @@
       return [[response rawString] objectFromJSON];
     } catch(ex) {
       if(console && console.error) {
-        console.error("RequestHelper#sync "+verb+" failed to convert response from "+url+" to JSON.", response);
+        console.error("RequestHelper#syncRequestWithVerb:url:object: failed to convert response from "+url+" to JSON.", response);
       }
     }
   }


### PR DESCRIPTION
Fixes RequestHelper syncRequestWithVerb to catch exception when parsing JSON and returning null instead of throwing an uncaught error
