### PR TITLE
Upgrade spring hibernate

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -11,9 +11,28 @@
   <version>0.9.0</version>
 
   <properties>
-    <spring.version>4.1.9.RELEASE</spring.version>
-    <spring.security.version>3.2.9.RELEASE</spring.security.version>
+    <spring.version>5.1.1.RELEASE</spring.version>
+    <spring.security.version>5.1.1.RELEASE</spring.security.version>
+    <hibernate.version>5.3.7.Final</hibernate.version>
+    <hibernate.validator.version>6.0.13.Final</hibernate.validator.version>
+    <mysql.connector.version>5.1.15</mysql.connector.version>
     <jetty.version>9.2.14.v20151106</jetty.version>
+    <jersey.version>1.17.1</jersey.version>
+    <com.google.gson.version>2.2.2</com.google.gson.version>
+    <com.google.guava.version>14.0.1</com.google.guava.version>
+    <slf4j.version>1.7.5</slf4j.version>
+    <apache.commons.httpclient.version>3.1</apache.commons.httpclient.version>
+    <apache.commons.dbcp.version>1.4</apache.commons.dbcp.version>
+    <apache.commons.daemon.version>1.0.3</apache.commons.daemon.version>
+    <apache.derby.version>10.14.2.0</apache.derby.version>
+    <net.sf.ehcache.version>2.6.11</net.sf.ehcache.version>
+    <cglib.version>2.2.2</cglib.version>
+    <javassist.version>3.13.0-GA</javassist.version>
+    <aspectj.version>1.9.2</aspectj.version>
+    <junit.version>4.8.2</junit.version>
+    <mockito.version>1.8.5</mockito.version>
+    <javax.el.version>3.0.1-b10</javax.el.version>
+
   </properties>
 
   <licenses>
@@ -69,30 +88,11 @@
   </build>
 
   <dependencies>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-      <version>${jetty.version}</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
+
+    <!-- SPRING START -->
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
-      <version>${spring.version}</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context</artifactId>
-      <version>${spring.version}</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-web</artifactId>
       <version>${spring.version}</version>
       <type>jar</type>
       <scope>compile</scope>
@@ -106,7 +106,14 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>spring-aop</artifactId>
+      <artifactId>spring-web</artifactId>
+      <version>${spring.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
       <version>${spring.version}</version>
       <type>jar</type>
       <scope>compile</scope>
@@ -120,155 +127,39 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-web</artifactId>
-      <version>${spring.security.version}</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
       <version>${spring.security.version}</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-server</artifactId>
-      <version>1.17.1</version>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-web</artifactId>
+      <version>${spring.security.version}</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-servlet</artifactId>
-      <version>1.17.1</version>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+      <version>${spring.version}</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>
+    <!-- SPRING END -->
+
+    <!-- HIBERNATE START -->
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>4.3.8.Final</version>
+      <version>${hibernate.version}</version>
       <type>jar</type>
       <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-validator</artifactId>
-      <version>4.1.0.Final</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.2.2</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>14.0.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.5</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.5</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jul-to-slf4j</artifactId>
-      <version>1.7.5</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>cglib</groupId>
-      <artifactId>cglib</artifactId>
-      <version>2.2.2</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-dbcp</groupId>
-      <artifactId>commons-dbcp</artifactId>
-      <version>1.4</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.derby</groupId>
-      <artifactId>derby</artifactId>
-      <version>10.8.2.2</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.javassist</groupId>
-      <artifactId>javassist</artifactId>
-      <version>3.13.0-GA</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.15</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.aspectj</groupId>
-      <artifactId>aspectjrt</artifactId>
-      <version>1.8.4</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.aspectj</groupId>
-      <artifactId>aspectjtools</artifactId>
-      <version>1.8.4</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-daemon</groupId>
-      <artifactId>commons-daemon</artifactId>
-      <version>1.0.3</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.8.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.8.5</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1</version>
-      <type>jar</type>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-ehcache</artifactId>
-      <version>4.3.8.Final</version>
+      <version>${hibernate.version}</version>
       <scope>compile</scope>
       <type>jar</type>
       <exclusions>
@@ -281,8 +172,190 @@
     <dependency>
       <groupId>net.sf.ehcache</groupId>
       <artifactId>ehcache-core</artifactId>
-      <version>2.5.7</version>
+      <version>${net.sf.ehcache.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <version>${hibernate.validator.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <!-- HIBERNATE END -->
+
+    <!-- MYSQL START -->
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>${mysql.connector.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <!-- MYSQL END -->
+
+    <!-- DERBY START -->
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derby</artifactId>
+      <version>${apache.derby.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <!-- DERBY END -->
+
+    <!-- APACHE COMMONS START -->
+    <dependency>
+      <groupId>commons-dbcp</groupId>
+      <artifactId>commons-dbcp</artifactId>
+      <version>${apache.commons.dbcp.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-daemon</groupId>
+      <artifactId>commons-daemon</artifactId>
+      <version>${apache.commons.daemon.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-httpclient</groupId>
+      <artifactId>commons-httpclient</artifactId>
+      <version>${apache.commons.httpclient.version}</version>
+      <type>jar</type>
+      <scope>test</scope>
+    </dependency>
+    <!-- APACHE COMMONS END -->
+
+    <!-- JERSEY START -->
+    <dependency>
+      <groupId>com.sun.jersey</groupId>
+      <artifactId>jersey-server</artifactId>
+      <version>${jersey.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.jersey</groupId>
+      <artifactId>jersey-servlet</artifactId>
+      <version>${jersey.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <!-- JERSEY END -->
+
+    <!-- JETTY START -->
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>${jetty.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <!-- JETTY END -->
+
+    <!-- GOOGLE START -->
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${com.google.gson.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${com.google.guava.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <!-- GOOGLE END -->
+
+    <!-- SLF4J START -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${slf4j.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+      <version>${slf4j.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <!-- SLF4J END -->
+
+    <!-- ASPECTJ START -->
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjrt</artifactId>
+      <version>${aspectj.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjtools</artifactId>
+      <version>${aspectj.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <!-- ASPECTJ END -->
+
+    <!-- JUNIT START -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- JUNIT END -->
+
+    <!-- MOCKITO START -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- MOCKITO END -->
+
+    <!-- JAVASSIST START -->
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <version>${javassist.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <!-- JAVASSIST END -->
+
+    <!-- CGLIB START -->
+    <dependency>
+      <groupId>cglib</groupId>
+      <artifactId>cglib</artifactId>
+      <version>${cglib.version}</version>
+    </dependency>
+    <!-- CGLIB END -->
+
+    <!-- JAVAX EL START -->
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.el</artifactId>
+      <version>${javax.el.version}</version>
+      <type>jar</type>
+    </dependency>
+    <!-- JAVAX EL END -->
+
   </dependencies>
 
 </project>

--- a/server/src/main/java/se/sperber/cryson/initialization/Application.java
+++ b/server/src/main/java/se/sperber/cryson/initialization/Application.java
@@ -32,7 +32,7 @@ import java.util.Properties;
 public class Application {
 
   private static AnnotationConfigApplicationContext context = null;
-  
+
   private static Properties properties = null;
 
   public static <T> T get(Class<T> type) {

--- a/server/src/main/java/se/sperber/cryson/repository/CrysonRepositoryExceptionTranslator.java
+++ b/server/src/main/java/se/sperber/cryson/repository/CrysonRepositoryExceptionTranslator.java
@@ -20,14 +20,16 @@ package se.sperber.cryson.repository;
 
 import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Aspect;
-import org.hibernate.OptimisticLockException;
 import org.hibernate.StaleObjectStateException;
+import org.hibernate.dialect.lock.OptimisticEntityLockException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.orm.hibernate3.HibernateOptimisticLockingFailureException;
+import org.springframework.orm.hibernate5.HibernateOptimisticLockingFailureException;
 import org.springframework.stereotype.Component;
 import se.sperber.cryson.exception.CrysonEntityConflictException;
 import se.sperber.cryson.exception.CrysonException;
+
+import javax.persistence.OptimisticLockException;
 
 @Component
 @Aspect
@@ -40,9 +42,10 @@ public class CrysonRepositoryExceptionTranslator {
     LOGGER.error("Translating exception", t);
     if (t instanceof CrysonException) {
       throw t;
-    } else if (t instanceof OptimisticLockException || t instanceof HibernateOptimisticLockingFailureException || t instanceof StaleObjectStateException) {
+    } else if (t instanceof OptimisticLockException || t instanceof OptimisticEntityLockException || t instanceof HibernateOptimisticLockingFailureException || t instanceof StaleObjectStateException) {
       throw new CrysonEntityConflictException("Optimistic locking failed", t);
     } else {
+      System.out.println(t.getClass().getName());
       throw new CrysonException("Unclassified error: " + t.getMessage(), t);
     }
   }

--- a/server/src/main/java/se/sperber/cryson/service/CrysonFrontendService.java
+++ b/server/src/main/java/se/sperber/cryson/service/CrysonFrontendService.java
@@ -20,13 +20,13 @@ package se.sperber.cryson.service;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.hibernate.OptimisticLockException;
 import org.hibernate.StaleObjectStateException;
+import org.hibernate.dialect.lock.OptimisticEntityLockException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
-import org.springframework.orm.hibernate3.HibernateOptimisticLockingFailureException;
+import org.springframework.orm.hibernate5.HibernateOptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -38,14 +38,13 @@ import se.sperber.cryson.serialization.CrysonSerializer;
 import se.sperber.cryson.util.StringUtils;
 
 import javax.annotation.PostConstruct;
+import javax.persistence.OptimisticLockException;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.*;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
 
 @Service
@@ -233,7 +232,7 @@ public class CrysonFrontendService {
     LOGGER.error("Error", t);
     if (t instanceof CrysonException) {
       return translateCrysonException((CrysonException)t);
-    } else if (t instanceof OptimisticLockException || t instanceof HibernateOptimisticLockingFailureException || t instanceof StaleObjectStateException) {
+    } else if (t instanceof OptimisticLockException || t instanceof OptimisticEntityLockException || t instanceof HibernateOptimisticLockingFailureException || t instanceof StaleObjectStateException) {
       return translateCrysonException(new CrysonEntityConflictException("Optimistic locking failed", t));
     } else if (t instanceof AccessDeniedException) {
       return Response.status(Response.Status.UNAUTHORIZED).entity(buildJsonMessage(t.getMessage())).build();

--- a/server/src/main/java/se/sperber/cryson/spring/WrappingWebApplicationContext.java
+++ b/server/src/main/java/se/sperber/cryson/spring/WrappingWebApplicationContext.java
@@ -3,11 +3,13 @@ package se.sperber.cryson.spring;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.MessageSourceResolvable;
 import org.springframework.context.NoSuchMessageException;
+import org.springframework.core.ResolvableType;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.Resource;
 import org.springframework.web.context.WebApplicationContext;
@@ -69,6 +71,11 @@ public class WrappingWebApplicationContext implements WebApplicationContext {
   }
 
   @Override
+  public void publishEvent(Object o) {
+
+  }
+
+  @Override
   public BeanFactory getParentBeanFactory() {
     return wrappedContext.getParentBeanFactory();
   }
@@ -91,6 +98,11 @@ public class WrappingWebApplicationContext implements WebApplicationContext {
   @Override
   public String[] getBeanDefinitionNames() {
     return wrappedContext.getBeanDefinitionNames();
+  }
+
+  @Override
+  public String[] getBeanNamesForType(ResolvableType resolvableType) {
+    return new String[0];
   }
 
   @Override
@@ -154,6 +166,16 @@ public class WrappingWebApplicationContext implements WebApplicationContext {
   }
 
   @Override
+  public <T> ObjectProvider<T> getBeanProvider(Class<T> aClass) {
+    return null;
+  }
+
+  @Override
+  public <T> ObjectProvider<T> getBeanProvider(ResolvableType resolvableType) {
+    return null;
+  }
+
+  @Override
   public boolean containsBean(String s) {
     return wrappedContext.containsBean(s);
   }
@@ -166,6 +188,11 @@ public class WrappingWebApplicationContext implements WebApplicationContext {
   @Override
   public boolean isPrototype(String s) throws NoSuchBeanDefinitionException {
     return wrappedContext.isPrototype(s);
+  }
+
+  @Override
+  public boolean isTypeMatch(String s, ResolvableType resolvableType) throws NoSuchBeanDefinitionException {
+    return false;
   }
 
   @Override

--- a/server/src/main/resources/cryson_database.xml
+++ b/server/src/main/resources/cryson_database.xml
@@ -5,16 +5,16 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="
-     http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-     http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-     http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.1.xsd">
+     http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+     http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+     http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd">
 
   <bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource"
         destroy-method="close" p:driverClassName="${cryson.database.driver}"
         p:url="${cryson.database.url}" p:username="${cryson.database.user}" p:password='${cryson.database.password}' />
 
   <bean id="sessionFactory"
-        class="org.springframework.orm.hibernate4.LocalSessionFactoryBean">
+        class="org.springframework.orm.hibernate5.LocalSessionFactoryBean">
     <property name="dataSource" ref="dataSource" />
     <property name="packagesToScan">
       <list>
@@ -27,17 +27,21 @@
         hibernate.show_sql=false
         hibernate.hbm2ddl.auto=update
         hibernate.dialect=${cryson.database.dialect}
-        hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.EhCacheRegionFactory
+        hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.internal.EhcacheRegionFactory
         hibernate.cache.use_second_level_cache=${cryson.database.use_cache}
         hibernate.cache.use_query_cache=${cryson.database.use_cache}
         hibernate.cache.use_minimal_puts=${cryson.database.use_cache}
-        net.sf.ehcache.configurationResourceName=/cryson_ehcache.xml
+        hibernate.allow_update_outside_transaction=true
+        hibernate.id.new_generator_mappings=false
+        hibernate.query.sql.jdbc_style_params_base=true
+        hibernate.cache.ehcache.missing_cache_strategy=create
+        net.sf.ehcache.configurationResourceName=cryson_ehcache.xml
       </value>
     </property>
   </bean>
 
   <bean id="transactionManager"
-        class="org.springframework.orm.hibernate4.HibernateTransactionManager"
+        class="org.springframework.orm.hibernate5.HibernateTransactionManager"
         p:sessionFactory-ref="sessionFactory" />
 
   <tx:annotation-driven />

--- a/server/src/main/resources/cryson_ehcache.xml
+++ b/server/src/main/resources/cryson_ehcache.xml
@@ -17,13 +17,13 @@
           />
 
   <cache
-          name="org.hibernate.cache.StandardQueryCache"
+          name="org.hibernate.cache.spi.QueryCache"
           maxEntriesLocalHeap="100000"
           eternal="true"
           overflowToDisk="true"/>
 
   <cache
-          name="org.hibernate.cache.UpdateTimestampsCache"
+          name="default-update-timestamps-region"
           maxEntriesLocalHeap="100000"
           eternal="true"
           overflowToDisk="true"/>

--- a/server/src/main/resources/cryson_security.xml
+++ b/server/src/main/resources/cryson_security.xml
@@ -2,12 +2,13 @@
        xmlns:security="http://www.springframework.org/schema/security"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-          http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+          http://www.springframework.org/schema/beans/spring-beans.xsd
           http://www.springframework.org/schema/security
-          http://www.springframework.org/schema/security/spring-security-3.2.xsd">
+          http://www.springframework.org/schema/security/spring-security.xsd">
 
   <security:http auto-config="true">
     <security:http-basic/>
+    <security:csrf disabled="true" />
   </security:http>
 
   <security:authentication-manager alias="authenticationManager">

--- a/server/src/test/java/se/sperber/cryson/apitest/CrysonAPITest.java
+++ b/server/src/test/java/se/sperber/cryson/apitest/CrysonAPITest.java
@@ -73,10 +73,8 @@ public class CrysonAPITest {
   private static void cleanDatabase() {
     Session session = Application.get(SessionFactory.class).openSession();
     session.beginTransaction();
-    NativeQuery query1 = session.createSQLQuery("DELETE FROM CrysonTestChildEntity");
-    NativeQuery query2 = session.createSQLQuery("DELETE FROM CrysonTestEntity");
-    query1.executeUpdate();
-    query2.executeUpdate();
+    session.createSQLQuery("DELETE FROM CrysonTestChildEntity").executeUpdate();
+    session.createSQLQuery("DELETE FROM CrysonTestEntity").executeUpdate();
     session.getTransaction().commit();
     session.close();
   }

--- a/server/src/test/java/se/sperber/cryson/apitest/CrysonAPITest.java
+++ b/server/src/test/java/se/sperber/cryson/apitest/CrysonAPITest.java
@@ -31,6 +31,7 @@ import org.apache.commons.httpclient.methods.PutMethod;
 import org.apache.commons.httpclient.methods.StringRequestEntity;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.query.NativeQuery;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -71,8 +72,12 @@ public class CrysonAPITest {
 
   private static void cleanDatabase() {
     Session session = Application.get(SessionFactory.class).openSession();
-    session.createSQLQuery("DELETE FROM CrysonTestChildEntity").executeUpdate();
-    session.createSQLQuery("DELETE FROM CrysonTestEntity").executeUpdate();
+    session.beginTransaction();
+    NativeQuery query1 = session.createSQLQuery("DELETE FROM CrysonTestChildEntity");
+    NativeQuery query2 = session.createSQLQuery("DELETE FROM CrysonTestEntity");
+    query1.executeUpdate();
+    query2.executeUpdate();
+    session.getTransaction().commit();
     session.close();
   }
 

--- a/server/src/test/java/se/sperber/cryson/hibernate/CrysonHibernateTest.java
+++ b/server/src/test/java/se/sperber/cryson/hibernate/CrysonHibernateTest.java
@@ -6,8 +6,6 @@ import org.hibernate.query.NativeQuery;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
 import se.sperber.cryson.CrysonServer;
 import se.sperber.cryson.initialization.Application;
 import se.sperber.cryson.testutil.CrysonTestEntity;
@@ -22,6 +20,7 @@ public class CrysonHibernateTest {
   private static void cleanDatabase() {
     Session session = Application.get(SessionFactory.class).openSession();
     session.beginTransaction();
+    session.createSQLQuery("DELETE FROM CrysonTestChildEntity").executeUpdate();
     session.createSQLQuery("DELETE FROM CrysonTestEntity").executeUpdate();
     session.getTransaction().commit();
     session.close();

--- a/server/src/test/java/se/sperber/cryson/hibernate/CrysonHibernateTest.java
+++ b/server/src/test/java/se/sperber/cryson/hibernate/CrysonHibernateTest.java
@@ -1,0 +1,83 @@
+package se.sperber.cryson.hibernate;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.query.NativeQuery;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import se.sperber.cryson.CrysonServer;
+import se.sperber.cryson.initialization.Application;
+import se.sperber.cryson.testutil.CrysonTestEntity;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class CrysonHibernateTest {
+
+  private static CrysonServer crysonServer;
+
+  private static void cleanDatabase() {
+    Session session = Application.get(SessionFactory.class).openSession();
+    session.beginTransaction();
+    session.createSQLQuery("DELETE FROM CrysonTestEntity").executeUpdate();
+    session.getTransaction().commit();
+    session.close();
+  }
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    crysonServer = new CrysonServer();
+    crysonServer.init(new String[]{"cryson-test.properties"});
+    crysonServer.start();
+    cleanDatabase();
+  }
+
+  @AfterClass
+  public static void teardown() throws Exception {
+    crysonServer.stop();
+    crysonServer.destroy();
+  }
+
+  @Test
+  public void shouldAllowSaveOutsideTransaction() {
+    try (Session session = Application.get(SessionFactory.class).openSession()) {
+      CrysonTestEntity testEntity = new CrysonTestEntity(1L);
+      session.save(testEntity);
+      session.flush();
+    }
+  }
+
+  @Test
+  public void shouldAllowUpdateOutsideTransaction() {
+    try (Session session = Application.get(SessionFactory.class).openSession()) {
+      CrysonTestEntity testEntity = new CrysonTestEntity(1L);
+      testEntity.setName("Crydaughter");
+      session.save(testEntity);
+      session.flush();
+      session.evict(testEntity);
+
+      CrysonTestEntity mergedTestEntity = (CrysonTestEntity)session.merge(testEntity);
+      mergedTestEntity.setName("Cryson");
+
+      CrysonTestEntity test = session.get(CrysonTestEntity.class, testEntity.getId());
+      assertThat(test.getName(), is("Cryson"));
+    }
+  }
+
+  @Test
+  public void shouldUseZeroBasedJDBCStyleParameters() {
+    try (Session session = Application.get(SessionFactory.class).openSession()) {
+      CrysonTestEntity testEntity = new CrysonTestEntity(1L);
+      testEntity.setName("Crydaughter");
+      session.save(testEntity);
+      session.flush();
+      NativeQuery query = session.createSQLQuery("SELECT * FROM CrysonTestEntity WHERE name = ?")
+          .setParameter(0, "Crydaughter");
+      assertThat(query.getParameter(0).getPosition(), is(0));
+      assertThat(query.getParameterValue(0), is("Crydaughter"));
+    }
+  }
+}


### PR DESCRIPTION
Depends on -> https://github.com/deltaprojects/reborn/pull/494
------------------------

Hibernate 4.3.8 -> 5.3.7
Hibernate-Validator 4.1.0 -> 6.0.13
Spring 4.1.9 -> 5.1.1
Spring-Security 3.2.9 -> 5.1.1
AspectJ 1.8.4 -> 1.9.2
EhCache 2.5.7 -> 2.6.11


Introduced:
------------------------
org.glassfish.javax.el 3.0.1-b10

Removed:
------------------------


Changes to config in order to keep older version behaviour for some cases:
------------------------
hibernate.allow_update_outside_transaction=true
hibernate.id.new_generator_mappings=false
hibernate.query.sql.jdbc_style_params_base=true
spring-security:csrf disabled